### PR TITLE
Fix nunit-version declaration to restore compatibility with Jenkins xunit-publisher plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-nunit-reporter",
-  "version": "1.3.0",
+  "version": "1.3.2-dev",
   "description": "A NUnit test report formatter for Jest.",
   "main": "index.js",
   "scripts": {

--- a/src/Environment.js
+++ b/src/Environment.js
@@ -6,7 +6,7 @@ class Environment {
   
       this['environment'] = {
           _attr: {
-            'nunit-version': '2.4.0.0',
+            'nunit-version': '2.5.0.0',
             'clr-version': 'na',
             'os-version': os.release(),
             platform: os.platform(),

--- a/src/Environment.js
+++ b/src/Environment.js
@@ -6,7 +6,7 @@ class Environment {
   
       this['environment'] = {
           _attr: {
-            'nunit-version': 'na',
+            'nunit-version': '2.4.0.0',
             'clr-version': 'na',
             'os-version': os.release(),
             platform: os.platform(),


### PR DESCRIPTION
This PR declares the compatible NUnit version 2.5.0.0 in the `nunit-version` attribute of the generated report file.

This is required since using "na" causes an exception when the report is consumed by recent versions of the [Jenkins xunit plugin](https://plugins.jenkins.io/xunit). 

See also the related bug report [JENKINS-53165](https://issues.jenkins-ci.org/browse/JENKINS-53165) which suggests that this needs to be fixed on jest-nunit-reporter side.

*Note*: I also updated the jest-nunit-plugin version to "1.3.2-dev" as 1.3.1 is the latest published release currently